### PR TITLE
feat: add active profile option to editor

### DIFF
--- a/CustomizePlus/Armatures/Services/ArmatureManager.cs
+++ b/CustomizePlus/Armatures/Services/ArmatureManager.cs
@@ -423,7 +423,9 @@ public unsafe sealed class ArmatureManager : IDisposable
             type is not TemplateChanged.Type.DeletedBone &&
             type is not TemplateChanged.Type.EditorCharacterChanged &&
             type is not TemplateChanged.Type.EditorEnabled &&
-            type is not TemplateChanged.Type.EditorDisabled)
+            type is not TemplateChanged.Type.EditorDisabled &&
+            type is not TemplateChanged.Type.ActiveProfileApplicationEnabled &&
+            type is not TemplateChanged.Type.ActiveProfileApplicationDisabled)
             return;
 
         if (type == TemplateChanged.Type.NewBone ||
@@ -468,15 +470,15 @@ public unsafe sealed class ArmatureManager : IDisposable
         }
 
         if (type == TemplateChanged.Type.EditorEnabled ||
-            type == TemplateChanged.Type.EditorDisabled)
+            type == TemplateChanged.Type.EditorDisabled ||
+            type == TemplateChanged.Type.ActiveProfileApplicationEnabled ||
+            type == TemplateChanged.Type.ActiveProfileApplicationDisabled)
         {
             ActorIdentifier actor;
-            bool hasChanges;
-
-            if(type == TemplateChanged.Type.EditorEnabled)
-                actor = (ActorIdentifier)arg3;
+            if (type == TemplateChanged.Type.EditorDisabled)
+                (actor, _) = ((ActorIdentifier, bool))arg3;
             else
-                (actor, hasChanges) = ((ActorIdentifier, bool))arg3;
+                actor = (ActorIdentifier)arg3;
 
             foreach (var armature in GetArmaturesForCharacter(actor))
             {

--- a/CustomizePlus/Configuration/Data/PluginConfiguration.cs
+++ b/CustomizePlus/Configuration/Data/PluginConfiguration.cs
@@ -94,6 +94,8 @@ public class PluginConfiguration : IPluginConfiguration, ISavable
 
         public ActorIdentifier PreviewCharacter { get; set; } = ActorIdentifier.Invalid;
 
+        public bool ApplyActiveProfileInEditor { get; set; } = false;
+
         public int EditorValuesPrecision { get; set; } = 3;
 
         public BoneAttribute EditorMode { get; set; } = BoneAttribute.Position;

--- a/CustomizePlus/Templates/Events/TemplateChanged.cs
+++ b/CustomizePlus/Templates/Events/TemplateChanged.cs
@@ -20,6 +20,8 @@ public class TemplateChanged() : EventWrapper<TemplateChanged.Type, Template?, o
         EditorEnabled,
         EditorDisabled,
         EditorCharacterChanged,
+        ActiveProfileApplicationEnabled,
+        ActiveProfileApplicationDisabled,
         ReloadedAll,
         WriteProtection
     }

--- a/CustomizePlus/Templates/TemplateFileSystem.cs
+++ b/CustomizePlus/Templates/TemplateFileSystem.cs
@@ -81,6 +81,9 @@ public sealed class TemplateFileSystem : FileSystem<Template>, IDisposable, ISav
                 if (old == leaf2.Name || leaf2.Name.IsDuplicateName(out var baseName, out _) && baseName == old)
                     RenameWithDuplicates(leaf2, template.Name);
                 return;
+            case TemplateChanged.Type.ActiveProfileApplicationEnabled:
+            case TemplateChanged.Type.ActiveProfileApplicationDisabled:
+                return;
         }
     }
 

--- a/CustomizePlus/UI/Windows/Controls/TemplateCombo.cs
+++ b/CustomizePlus/UI/Windows/Controls/TemplateCombo.cs
@@ -148,6 +148,8 @@ public abstract class TemplateComboBase : FilterComboCache<Tuple<Template, strin
             TemplateChanged.Type.Created => true,
             TemplateChanged.Type.Renamed => true,
             TemplateChanged.Type.Deleted => true,
+            TemplateChanged.Type.ActiveProfileApplicationEnabled => _isCurrentSelectionDirty,
+            TemplateChanged.Type.ActiveProfileApplicationDisabled => _isCurrentSelectionDirty,
             _ => _isCurrentSelectionDirty,
         };
     }

--- a/CustomizePlus/UI/Windows/MainWindow/Tabs/Profiles/ProfilePanel.cs
+++ b/CustomizePlus/UI/Windows/MainWindow/Tabs/Profiles/ProfilePanel.cs
@@ -146,6 +146,8 @@ public class ProfilePanel
         if (!child || _selector.Selected == null)
             return;
 
+        using var disabledEditor = ImRaii.Disabled(_templateEditorManager.IsEditorActive && _templateEditorManager.ActiveProfileApplicationEnabled);
+
         DrawEnabledSetting();
 
         ImGui.Separator();

--- a/CustomizePlus/UI/Windows/MainWindow/Tabs/Templates/BoneEditorPanel.cs
+++ b/CustomizePlus/UI/Windows/MainWindow/Tabs/Templates/BoneEditorPanel.cs
@@ -39,6 +39,7 @@ public class BoneEditorPanel
 
     private bool _isShowLiveBones;
     private bool _isMirrorModeEnabled;
+    private bool _applyActiveProfile;
 
     private Dictionary<BoneData.BoneFamily, bool> _groupExpandedState = new();
 
@@ -82,6 +83,7 @@ public class BoneEditorPanel
 
         _isShowLiveBones = configuration.EditorConfiguration.ShowLiveBones;
         _isMirrorModeEnabled = configuration.EditorConfiguration.BoneMirroringEnabled;
+        _applyActiveProfile = configuration.EditorConfiguration.ApplyActiveProfileInEditor;
         _precision = configuration.EditorConfiguration.EditorValuesPrecision;
         _editingAttribute = configuration.EditorConfiguration.EditorMode;
         _favoriteBones = new HashSet<string>(_configuration.EditorConfiguration.FavoriteBones);
@@ -257,6 +259,15 @@ public class BoneEditorPanel
 
                 using (var disabled = ImRaii.Disabled(!_isUnlocked))
                 {
+                    ImGui.SameLine();
+                    if (CtrlHelper.Checkbox("Apply Active Profile", ref _applyActiveProfile))
+                    {
+                        _configuration.EditorConfiguration.ApplyActiveProfileInEditor = _applyActiveProfile;
+                        _configuration.Save();
+                        _editorManager.SetActiveProfileApplicationEnabled(_applyActiveProfile);
+                    }
+                    CtrlHelper.AddHoverText("Apply templates from the currently active profile while editing.");
+
                     ImGui.SameLine();
                     if (CtrlHelper.Checkbox("Show Live Bones", ref _isShowLiveBones))
                     {

--- a/CustomizePlus/UI/Windows/MainWindow/Tabs/Templates/TemplateFileSystemSelector.cs
+++ b/CustomizePlus/UI/Windows/MainWindow/Tabs/Templates/TemplateFileSystemSelector.cs
@@ -265,6 +265,8 @@ public class TemplateFileSystemSelector : FileSystemSelector<Template, TemplateS
             case TemplateChanged.Type.Deleted:
             case TemplateChanged.Type.Renamed:
             case TemplateChanged.Type.ReloadedAll:
+            case TemplateChanged.Type.ActiveProfileApplicationEnabled:
+            case TemplateChanged.Type.ActiveProfileApplicationDisabled:
                 SetFilterDirty();
                 break;
         }


### PR DESCRIPTION
## Summary
- add configuration flag to apply active profile during template editing
- toggle active profile use in template editor and rebuild editor profile dynamically
- lock profile panel when active profile application is active

## Testing
- `dotnet build` *(fails: The project file "/workspace/CustomizePlus/submodules/OtterGui/OtterGui.csproj" was not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c022123cbc8328b98d2405eb8ab33a