### PR TITLE
Remove unused editor profile flag

### DIFF
--- a/CustomizePlus/Templates/TemplateEditorManager.cs
+++ b/CustomizePlus/Templates/TemplateEditorManager.cs
@@ -83,8 +83,6 @@ public class TemplateEditorManager : IDisposable
         }
     }
 
-    public bool IsKeepOnlyEditorProfileActive { get; set; } //todo
-
     public bool ActiveProfileApplicationEnabled => _activeProfileApplicationEnabled;
 
     private bool _activeProfileApplicationEnabled;


### PR DESCRIPTION
## Summary
- remove unused IsKeepOnlyEditorProfileActive property in TemplateEditorManager

## Testing
- `rg IsKeepOnlyEditorProfileActive -n`
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_68c0308b33508328a092125d5f6053b1